### PR TITLE
support AWS::XRay's plugins

### DIFF
--- a/lib/Plack/Middleware/XRay.pm
+++ b/lib/Plack/Middleware/XRay.pm
@@ -27,6 +27,10 @@ sub call {
         AWS::XRay->auto_flush(0);
     }
 
+    if (ref $self->{plugins} eq "ARRAY") {
+        AWS::XRay->plugins(@{ $self->{plugins} });
+    }
+
     my $t0 = [ Time::HiRes::gettimeofday ];
     my $res = capture_from $env->{$trace_header_key}, $self->{name}, sub {
         my $segment = shift;
@@ -197,6 +201,14 @@ Code ref to generate a metadata hashref.
 When response_filter defined, call the coderef with ($env, $res, $elapsed) after $app run.
 
 Segment data are sent to xray daemon only when the coderef returns true.
+
+=head2 plugins
+
+When plugins defined, AWS::XRay enables these plugins.
+
+    enable "XRay"
+      name => "myApp",
+      plugins => ["AWS::XRay::Plugin::EC2"],
 
 =head1 LICENSE
 


### PR DESCRIPTION
ref: https://github.com/fujiwara/AWS-XRay/pull/6

Now, AWS::XRay supports EC2 plugin, but Plack::Middleware::XRay can not load that plugin.
In this pull request, I implement that Plack::Middleware::XRay can enable AWS::XRay's plugin.